### PR TITLE
Add filament sensor config entry for sensor on E0 on SKR Pico

### DIFF
--- a/Firmware/printer.cfg
+++ b/Firmware/printer.cfg
@@ -382,6 +382,12 @@ gcode_id: chamber_th
 #switch_pin: umb:gpio6
 #pause_on_runout: True
 
+## FS - SKR Pico (as per the V0r1 guide: https://docs.ldomotors.com/en/voron/voron02/wiring_guide_rev_a#installing-the-filament-sensor-cable)
+## Filament Sensor 1
+#[filament_switch_sensor runout_sensor]
+#switch_pin: ^gpio16
+#pause_on_runout: True
+
 ## SU - Frame PCB
 ## Filament Sensor 2
 #[gcode_button filament_sensor_button]


### PR DESCRIPTION
Added missing entry for the filament sensor connected to the SKR Pico's E0 port as per the official LDO documentation: https://docs.ldomotors.com/en/voron/voron02/wiring_guide_rev_a#installing-the-filament-sensor-cable

The entry was missing and I researched what config entry to create to make it work with my latest V0r1-S1 build from the LDO kit.